### PR TITLE
Improve callback UX and remove remote font dependency

### DIFF
--- a/src/app/edv/callback/route.ts
+++ b/src/app/edv/callback/route.ts
@@ -1,27 +1,35 @@
-export async function GET(req: Request) {
+export async function GET() {
   const html = `<!doctype html>
-  <html>
+  <html lang="tr">
     <head>
       <meta charset="utf-8" />
       <title>e-Devlet callback</title>
       <meta name="viewport" content="width=device-width,initial-scale=1" />
+      <meta name="color-scheme" content="light dark" />
+      <style>
+        body {
+          font-family: system-ui, sans-serif;
+          margin: 0;
+          padding: 2rem;
+          text-align: center;
+        }
+      </style>
     </head>
     <body>
+      <p id="message">İşlem tamamlanıyor...</p>
       <script>
         (function(){
           try {
             var q = location.search || '';
             if (window.opener && !window.opener.closed) {
-              // send the query string back to the opener (same-origin expected)
               window.opener.postMessage({ type: 'edv_callback', query: q }, window.origin);
-              // try to close the popup; if blocked, leave a message
               try { window.close(); } catch (e) {}
-              document.body.innerHTML = '<p>Giriş tamamlandı. Pencere kapanıyor...</p>';
+              document.getElementById('message').textContent = 'Giriş tamamlandı. Pencere kapanıyor...';
             } else {
-              document.body.innerHTML = '<p>Pencere sahibi bulunamadı. Bu sekmeyi kapatıp uygulamaya dönün.</p>';
+              document.getElementById('message').textContent = 'Pencere sahibi bulunamadı. Bu sekmeyi kapatıp uygulamaya dönün.';
             }
           } catch (err) {
-            document.body.innerHTML = '<p>Callback sırasında hata oluştu.</p>';
+            document.getElementById('message').textContent = 'Callback sırasında hata oluştu.';
           }
         })();
       </script>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -23,12 +12,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+    <html lang="tr">
+      <body className="antialiased">{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- Modernize e-Devlet callback page and handle messages gracefully
- Drop remote Google font usage to enable offline builds

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc586418088326895f062d4cb15c52