### PR TITLE
Add Ant Design React 19 compatibility shim

### DIFF
--- a/src/app/tareks/_components/sidebar-content.tsx
+++ b/src/app/tareks/_components/sidebar-content.tsx
@@ -1,5 +1,6 @@
 ﻿"use client";
 
+import "@/lib/antd-compat";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/src/app/tareks/dosya/[masterId]/kalemler/edit/page.tsx
+++ b/src/app/tareks/dosya/[masterId]/kalemler/edit/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/lib/antd-compat";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { Button, Input, Space, Table, Tooltip, message } from "antd";

--- a/src/app/tareks/dosya/[masterId]/kalemler/fill/page.tsx
+++ b/src/app/tareks/dosya/[masterId]/kalemler/fill/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/lib/antd-compat";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { Button, Table, message } from "antd";

--- a/src/app/tareks/dosya/[masterId]/page.tsx
+++ b/src/app/tareks/dosya/[masterId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/lib/antd-compat";
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams, useParams } from "next/navigation";
 import Link from "next/link";

--- a/src/app/tareks/page.tsx
+++ b/src/app/tareks/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/lib/antd-compat";
 import React, { useMemo, useState } from "react";
 import { Table, Input, Select, Button, Space, Tag, Tooltip, message } from "antd";
 import type { ColumnsType } from "antd/es/table";

--- a/src/app/tareks/para-istem/page.tsx
+++ b/src/app/tareks/para-istem/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/lib/antd-compat";
 import { useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Button, Input, Select, Table, message, Modal, Form } from "antd";

--- a/src/lib/antd-compat.ts
+++ b/src/lib/antd-compat.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import * as ReactDOM from "react-dom";
+import { createRoot, hydrateRoot } from "react-dom/client";
+
+// React 19 no longer exposes `createRoot`/`hydrateRoot` on the `react-dom`
+// entry. Ant Design v5 still checks for these keys to detect compatible
+// environments. We re-export the client helpers onto the `react-dom` namespace
+// so Ant Design can operate without showing the compatibility warning.
+type ReactDOMWithCompat = typeof ReactDOM & {
+  createRoot?: typeof createRoot;
+  hydrateRoot?: typeof hydrateRoot;
+};
+
+const reactDom = ReactDOM as ReactDOMWithCompat;
+
+if (!reactDom.createRoot) {
+  reactDom.createRoot = createRoot;
+}
+
+if (!reactDom.hydrateRoot) {
+  reactDom.hydrateRoot = hydrateRoot;
+}


### PR DESCRIPTION
## Summary
- add a small client-side shim that re-exports React 19 root APIs onto `react-dom` so Ant Design detects compatibility
- load the shim in every Ant Design-powered client page to silence the runtime warning

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6180d3588326b0b3ca2ae01770c8